### PR TITLE
fix(action): skip publish on dependabot push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ name: Publish
   push:
     branches:
       - "master"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
* fix(action): skip publish on dependabot push
    As dependabot actor can't access the secrets to push images,
    any push to master by dependabot should not trigger the action.

* feat(action): enable manual trigger on publish
