### PR TITLE
ci(actions): adjust release creation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+---
+changelog:
+  categories:
+    - title: "✨ Features"
+      labels:
+        - enhancement
+    - title: "🐛 Bugfixes"
+      labels:
+        - bug
+    - title: "⬆️ Updates"
+      labels:
+        - dependencies
+        - github_actions
+    - title: "📝️ Documentation"
+      labels:
+        - documentation
+    - title: "🌐 Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,12 +2,11 @@
 name: Publish
 
 "on":
-  release:
-    types: [published]
   push:
     branches:
       - "master"
-  workflow_dispatch:
+    tags:
+      - "v*"
 
 jobs:
   publish:


### PR DESCRIPTION
### ci(actions): adjust release workflow trigger

Remove `release` and `workflow_dispatch` as triggers and use `push`
with branches and tags as described in

- https://github.com/docker/metadata-action#semver

### ci(actions): add release note configuration

- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
