### PR TITLE
ci(actions): enable workflows_dispatch for publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,13 +7,14 @@ name: Publish
       - "master"
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
To build latest image for pull requests merged by dependabot.
