### PR TITLE
ci(actions): adjust linter workflow

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -17,19 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # fetch-depth: 0 # can be removed if VALIDATE_ALL_CODEBASE = true
+          fetch-depth: 0
 
       - name: Lint
         uses: oxsecurity/megalinter/flavors/ci_light@v7 # see https://megalinter.io/flavors/
         # See https://megalinter.io/configuration/ for all available configurations
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true  # Lint only changed files
+          VALIDATE_ALL_CODEBASE: false
           APPLY_FIXES: none
           LOG_LEVEL: INFO
           PRINT_ALPACA: false


### PR DESCRIPTION
Add missing permissions, so that the action can comment on the pull
requests.
And adjust mega-linter configuration to lint only changed files.
