### PR TITLE
fix(dependabot): fix pip ecosystem directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       prefix: "chore(actions): "
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/.github/workflows/python-pubsub"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
The check does not search recursively, so the directory needs to be
adjusted to point to where the requirements.txt is.
