### PR TITLE
fix(actions): adjust permission for publish sarif file

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     env:
       IMAGE_NAME: docker.io/tungbeier/gcloud-pubsub-emulator


### PR DESCRIPTION
https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository
