### PR TITLE
ci(actions): scan and test image in parallel

### DIFF
--- a/.github/workflows/verify-pullrequest.yaml
+++ b/.github/workflows/verify-pullrequest.yaml
@@ -13,6 +13,12 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+env:
+  image_tag: "tungbeier/gcloud-pubsub-emulator:test"
+  python_version: "3.11"
+  artifact_name: "test-image"
+  image_path: "/tmp/test-image.tar"
+
 jobs:
   preparation:
     name: Prepare for build
@@ -39,14 +45,12 @@ jobs:
             .github/workflows/publish.yaml
             .github/workflows/verify-pullrequest.yaml
 
-  verify_pull_request:
-    name: Verify changes
+  build:
+    name: Build image
     runs-on: ubuntu-latest
     needs: preparation
     timeout-minutes: 30
     if: ${{ github.event.pull_request.draft == false && needs.preparation.outputs.has_changed == 'true' }}
-    env:
-      image_tag: "tungbeier/gcloud-pubsub-emulator:test"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,6 +64,30 @@ jobs:
           context: .
           load: true
           tags: ${{ env.image_tag }}
+          outputs: type=docker,dest=${{ env.image_path }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.artifact_name }}
+          path: ${{ env.image_path }}
+
+  scan_image:
+    name: Scan image
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 30
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.artifact_name }}
+          path: /tmp
+
+      - name: Load image
+        run: |
+          docker load --input ${{ env.image_path }}
+          docker image ls -a
 
       - name: Scan image
         uses: aquasecurity/trivy-action@0.16.1
@@ -71,12 +99,32 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL'
 
+  test:
+    name: Verify changes
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 30
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.artifact_name }}
+          path: /tmp
+
+      - name: Load image
+        run: |
+          docker load --input ${{ env.image_path }}
+          docker image ls -a
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '${{ env.python_version }}'
 
-      - name: Verify image
+      - name: Run test
         env:
           project: 'test-project'
           topic: 'test-topic'


### PR DESCRIPTION
Upload the built image to enable scanning and running tests against
it in parallel to speed up pull request verification.

See also:
- https://docs.docker.com/build/ci/github-actions/share-image-jobs/
