### PR TITLE
ci(actions): use local action to build image

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,0 +1,18 @@
+---
+name: 'build-image'
+description: 'Build the image in this repository'
+inputs:
+  image:
+    description: 'The image tag to be used for the build'
+    required: false
+    default: 'tungbeier/gcloud-pubsub-emulator:test'
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/setup-buildx-action@v3
+
+    - uses: docker/build-push-action@v5
+      with:
+        context: .
+        load: true
+        tags: ${{ inputs.image }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
     commit-message:
       prefix: "chore(actions): "
 
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/build-image"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(actions): "
+
   - package-ecosystem: "pip"
     directory: "/.github/workflows/python-pubsub"
     schedule:

--- a/.github/workflows/verify-pullrequest.yaml
+++ b/.github/workflows/verify-pullrequest.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+env:
+  image_tag: "tungbeier/gcloud-pubsub-emulator:test"
+
 jobs:
   preparation:
     name: Prepare for build
@@ -39,27 +42,17 @@ jobs:
             .github/workflows/publish.yaml
             .github/workflows/verify-pullrequest.yaml
 
-  verify_pull_request:
-    name: Verify changes
+  scan_image:
+    name: Scan image
     runs-on: ubuntu-latest
     needs: preparation
     timeout-minutes: 30
     if: ${{ github.event.pull_request.draft == false && needs.preparation.outputs.has_changed == 'true' }}
-    env:
-      image_tag: "tungbeier/gcloud-pubsub-emulator:test"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build image
-        uses: docker/build-push-action@v5
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-image
         with:
-          context: .
-          load: true
-          tags: ${{ env.image_tag }}
+          image: ${{ env.image_tag }}
 
       - name: Scan image
         uses: aquasecurity/trivy-action@0.16.1
@@ -71,12 +64,24 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL'
 
+  test_image:
+    name: Test image
+    runs-on: ubuntu-latest
+    needs: preparation
+    timeout-minutes: 30
+    if: ${{ github.event.pull_request.draft == false && needs.preparation.outputs.has_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-image
+        with:
+          image: ${{ env.image_tag }}
+
       - name: Set up python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Verify image
+      - name: Run tests
         env:
           project: 'test-project'
           topic: 'test-topic'


### PR DESCRIPTION
To speed up the pull request checks, run the scanning and testing of
the image in parallel.
And to not copy and paste the build process of the test image, move it
to a local composite action.
