### PR TITLE
ci: adapt structure test jdk expectations

### DIFF
--- a/.github/workflows/verify-pullrequest.yaml
+++ b/.github/workflows/verify-pullrequest.yaml
@@ -38,6 +38,7 @@ jobs:
           files: |
             Dockerfile
             run.sh
+            container-structure-test.yaml
             .github/workflows/python-pubsub/**
             .github/workflows/publish.yaml
             .github/workflows/verify-pullrequest.yaml

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -18,7 +18,7 @@ commandTests:
     command: 'java'
     args: ['--version']
     expectedOutput:
-      - '.*openjdk 17\.0\.9.+'
+      - '.*openjdk 17\.(\d{1,}\.\d{1,}).+'
       - '.*OpenJDK Runtime Environment.+'
       - '.*OpenJDK 64-Bit Server VM.+'
 


### PR DESCRIPTION
Change the regex to match all java 17 versions.
